### PR TITLE
Reconnect method when client loses connection

### DIFF
--- a/src/mqtt_bridge/bridge.py
+++ b/src/mqtt_bridge/bridge.py
@@ -343,7 +343,13 @@ class RemoteService(Bridge):
 
         self._srv_type_name = srv_type
         self._srv_type = lookup_object(self._srv_type_name)
-        self._serviceproxy = rospy.Service(self._local_server, self._srv_type, self._ros_handler)
+
+        try:
+            self._serviceproxy = rospy.Service(self._local_server, self._srv_type, self._ros_handler)
+        except rospy.ServiceException as e:
+            rospy.logerr("Captured exception when trying to register a "
+            "service twice. This happens when mqtt clients lose connection:"
+                " %s" % (e,))
 
     def _ros_handler(self, req):
 


### PR DESCRIPTION
- I added a new method in app.py to reconnect the mqtt_client without relaunching the ros node.
- Capture ServiceException when client tries to reconnect in bridge.py.