### PR TITLE
fix: Subscribe again to MQTT topic after a reconnection

### DIFF
--- a/src/mqtt_bridge/app.py
+++ b/src/mqtt_bridge/app.py
@@ -48,14 +48,22 @@ def mqtt_bridge_node():
     inject.configure(config)
 
     # configure and connect to MQTT broker
-    mqtt_client.on_connect = _on_connect
-    mqtt_client.on_disconnect = _on_disconnect
-    mqtt_client.connect(**conn_params)
+    # mqtt_client.on_connect = _on_connect
+    # mqtt_client.on_disconnect = _on_disconnect
+    # mqtt_client.connect(**conn_params)
 
     # configure bridges
     bridges = []
     for bridge_args in bridge_params:
         bridges.append(create_bridge(**bridge_args))
+
+    mqtt_client.user_data_set(bridges)
+
+    # Register callbacks
+    mqtt_client.on_connect = _on_connect
+    mqtt_client.on_disconnect = _on_disconnect
+
+    mqtt_client.connect(**conn_params)
 
     # start MQTT loop
     mqtt_client.loop_start()
@@ -68,6 +76,10 @@ def mqtt_bridge_node():
 
 def _on_connect(client, userdata, flags, response_code):
     rospy.loginfo('MQTT connected')
+    bridges = userdata or []
+    for bridge in bridges:
+        if hasattr(bridge, "subscribe"):
+            bridge.subscribe()
 
 
 def _on_disconnect(client, userdata, response_code):

--- a/src/mqtt_bridge/bridge.py
+++ b/src/mqtt_bridge/bridge.py
@@ -77,8 +77,17 @@ class MqttToRosBridge(Bridge):
         # Adding the correct topic to subscribe to
         self._mqtt_client.subscribe(self._topic_from)
         self._mqtt_client.message_callback_add(self._topic_from, self._callback_mqtt)
+        self.subscribe()
         self._publisher = rospy.Publisher(
             self._topic_to, self._msg_type, queue_size=self._queue_size)
+    
+    def subscribe(self):
+        result, mid = self._mqtt_client.subscribe(self._topic_from)
+        if result != mqtt.MQTT_ERR_SUCCESS:
+            rospy.logwarn("Failed to subscribe to MQTT topic {}: result={}".format(
+                self._topic_from, result))
+        else:
+            rospy.loginfo("Subscribed to MQTT topic {}".format(self._topic_from))
 
     def _callback_mqtt(self, client: mqtt.Client, userdata: Dict, mqtt_msg: mqtt.MQTTMessage):
         """ callback from MQTT """


### PR DESCRIPTION
This pull request refactors the MQTT bridge node initialization and improves the MQTT topic subscription process. The main changes focus on making the subscription process more robust and ensuring that topic subscriptions are properly handled and logged.

MQTT bridge node initialization and subscription improvements:

* Refactored the initialization sequence in `mqtt_bridge_node` to set MQTT client user data to the list of bridges, register callbacks after bridge creation, and then connect to the MQTT broker. This ensures that callbacks have access to bridge objects during connection events.
* Modified the `_on_connect` callback to iterate over the bridges and call their `subscribe` method if available, ensuring all bridges are subscribed to their topics upon connection.

Bridge subscription handling:

* Added a `subscribe` method to the `Bridge` class in `bridge.py`, which subscribes to the MQTT topic, checks for errors, and logs the result. The `subscribe` method is now called both during initialization and upon connection.